### PR TITLE
glab: install from alpine community repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,23 +12,6 @@
 # OTHER  TORTIOUS ACTION,  ARISING OUT  OF  OR IN  CONNECTION WITH  THE USE  OR
 # PERFORMANCE OF THIS SOFTWARE.
 
-FROM golang:1.15-alpine AS build-glab
-
-ARG GLAB_VERSION="1.12.1"
-
-RUN apk add --no-cache --quiet \
-      build-base \
-      ca-certificates \
-      git \
-      make
-
-RUN mkdir -p /go/src/github.com/profclems && \
-    cd /go/src/github.com/profclems && \
-    git clone https://github.com/profclems/glab.git && \
-    cd /go/src/github.com/profclems/glab && \
-    git checkout v${GLAB_VERSION} && \
-    make
-
 FROM golang:1.15-alpine AS build-hub
 
 ARG HUB_VERSION="2.14.2"
@@ -66,12 +49,12 @@ RUN mkdir -p /go/src/github.com/zaquestion && \
 
 FROM alpine:3.12
 
+RUN echo "@edge http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories
+
 RUN apk add --no-cache --quiet \
       git \
-      openssh-client
-
-COPY --from=build-glab /go/src/github.com/profclems/glab/bin/glab \
-                       /usr/bin/glab
+      openssh-client \
+      glab@edge
 
 COPY --from=build-hub  /go/src/github.com/github/hub/bin/hub \
                        /usr/bin/hub


### PR DESCRIPTION
glab is now available on the Alpine Community Repo as glab.
https://github.com/profclems/glab/#alpine-linux.

Instead of manually updating to newer versions, we install directly from the alpine community repo.
`@edge` is specified because the package is currently only available under the `edge`. This is necessary until alpine:3.13